### PR TITLE
Fix value map misinterpretation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 dist
 *.egg-info
 go.sh
+*,cover

--- a/modbus4mqtt/modbus4mqtt.py
+++ b/modbus4mqtt/modbus4mqtt.py
@@ -2,7 +2,7 @@
 
 from time import sleep
 import logging
-import yaml
+from ruamel.yaml import YAML
 import click
 import paho.mqtt.client as mqtt
 
@@ -148,7 +148,8 @@ class mqtt_interface():
             self._mb.set_value(register.get('table', 'holding'), register['address'], int(value), register.get('mask', 0xFFFF))
 
     def _load_modbus_config(self, path):
-        return yaml.load(open(path,'r').read(), Loader=yaml.FullLoader)
+        yaml=YAML(typ='safe')
+        return yaml.load(open(path,'r').read())
 
     def loop_forever(self):
         while True:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://github.com/tjhowse/modbus4mqtt",
     packages=setuptools.find_packages(),
     install_requires=[
-        'pyyaml>=3.5.0',
+        'ruamel.yaml>=0.16.12',
         'paho-mqtt>=1.5.0',
         'pymodbus>=2.3.0',
         'click>=6.7',

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -186,18 +186,23 @@ class MQTTTests(unittest.TestCase):
                 m.connect()
                 self.modbus_tables['holding'][1] = 1
                 self.modbus_tables['holding'][2] = 2
+                self.modbus_tables['holding'][3] = 1
                 m.poll()
 
+                print(mock_mqtt.mock_calls)
                 mock_mqtt().publish.assert_any_call(MQTT_TOPIC_PREFIX+'/value_map_absent', 1, retain=False)
                 mock_mqtt().publish.assert_any_call(MQTT_TOPIC_PREFIX+'/value_map_present', 'b', retain=False)
+                mock_mqtt().publish.assert_any_call(MQTT_TOPIC_PREFIX+'/value_map_misinterpretation', 'on', retain=False)
                 mock_mqtt().publish.reset_mock()
 
                 # This value is outside the map, check it comes through in raw form
                 self.modbus_tables['holding'][2] = 3
+                self.modbus_tables['holding'][3] = 2
                 m.poll()
 
-                # print(mock_mqtt.mock_calls)
+                print(mock_mqtt.mock_calls)
                 mock_mqtt().publish.assert_any_call(MQTT_TOPIC_PREFIX+'/value_map_present', 3, retain=False)
+                mock_mqtt().publish.assert_any_call(MQTT_TOPIC_PREFIX+'/value_map_misinterpretation', 'off', retain=False)
                 mock_mqtt().publish.reset_mock()
 
     def test_invalid_address(self):

--- a/tests/test_value_map.yaml
+++ b/tests/test_value_map.yaml
@@ -9,3 +9,8 @@ registers:
     value_map:
       a: 1
       b: 2
+  - pub_topic: "value_map_misinterpretation"
+    address: 3
+    value_map:
+      on: 1
+      off: 2


### PR DESCRIPTION
A fix for #7. Migrating to a different YAML loader that supports v1.2, which removed the interpretation of "on" and "off" as booleans. Value maps will properly be interpreted as strings.