### PR TITLE
add example config file for sungrow SG5K-D inverter

### DIFF
--- a/modbus4mqtt/SG5K-D.yaml
+++ b/modbus4mqtt/SG5K-D.yaml
@@ -1,0 +1,65 @@
+ip: 192.168.1.xxx #your inverter ip address
+port: 502
+update_rate: 60
+address_offset: 0
+variant: sungrow
+scan_batching: 1
+registers:
+  - pub_topic: "output_power" #total output power kWh
+    address: 5000
+    table: 'input'
+  - pub_topic: "daily_yield"  #daily yield kWh
+    address: 5002
+    table: 'input'
+  - pub_topic: "total_yield"  #Total yield kWh
+    address: 5003
+    table: 'input'
+  - pub_topic: "total_running_time"  #Total running time (h)
+    address: 5003
+    table: 'input'
+  - pub_topic: "internal_temperature" #inverter internal temperature 0.1C
+    address: 5007
+    table: 'input'
+  - pub_topic: "dc_output"  #dc output power (W)
+    address: 5016
+    table: 'input'
+  - pub_topic: "phase_a_voltage" #Phase A Voltage (0.1V)
+    address: 5018
+    table: 'input'
+  - pub_topic: "phase_a_current" #Phase A Current (0.1A)
+    address: 5021
+    table: 'input'
+  - pub_topic: "ac_output" #AC output power, total active power (W)
+    address: 5030
+    table: 'input'
+  - pub_topic: "power_factor" #Power factor (0.001)
+    address: 5034
+    table: 'input'
+  - pub_topic: "grid_frequency" #Grid Frequency (0.1Hz)
+    address: 5035
+    table: 'input'
+  - pub_topic: "device_state" #Device State  (see comments below for states)
+    address: 5037
+    table: 'input'
+  - pub_topic: "daily_running_time" #Daily running time (1m)
+    address: 5112
+    table: 'input'
+
+    #see https://github.com/tjhowse/modbus4mqtt/files/5732710/TI_20190704_Communication.Protocol.for.Residential.Single-phase.Grid-Connected.Inverters_V10_EN.pdf for full list of registers and details
+
+    # Device States (register 5037)
+    #
+    #0 Run
+    #1 Stop (normal stop)
+    #2 Initial Standby
+    #3 Key stop
+    #4 Standby
+    #5 Emergency Stop
+    #6 Startup
+    #7 Stopping
+    #9 Fault stop
+    #10 Alarm Run
+    #11 Derating run
+    #12 Limited run
+    #13 Communication fault
+    #16 Sleeping


### PR DESCRIPTION
Hey Travis (and others)

I've been watching https://github.com/tjhowse/modbus4mqtt/issues/16 closely and finally found some time to jump in and test out your library with our Sungrow SG5K-D inverter.  I looked at a lot of options for connecting our inverter up to home assistant, and from reading, this seemed like the most active place for our particular inverter / issues.  Many thanks must go to all involved, without all the details, I wouldn't have known where to start.

I am seeing some exceptions thrown on some registers some of the time, but generally the 5016 and 5030 ones are the ones that consistently update, which kind of makes sense to me, as these the ones that change most regularly.  I pushed out the polling rate to see how that affects it, and without proof, it feels like there are less exceptions.  I also found that setting the scan_batching to 1 helped get more registers to report values, but again, no firm proof.

My PR extends on the zip file that was uploaded to the above issue, and added some more registers that I had worked out myself from the documentation.

Just a FYI, I was having issues just prior to xmas with iSolarCloud but I could still read off the inverter with your code, exactly the opposite from what others were reporting....but it seems to have stabilised today, and I've had no trouble reading both.

