### PR TITLE
Bump the required version of Sungrow-Modbus to include PyCrypto repla…

### DIFF
--- a/modbus4mqtt/version.py
+++ b/modbus4mqtt/version.py
@@ -1,1 +1,1 @@
-version="0.5.0"
+version="0.5.1"

--- a/modbus4mqtt/version.py
+++ b/modbus4mqtt/version.py
@@ -1,1 +1,1 @@
-version="0.5.1"
+version = "0.5.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ruamel.yaml>=0.16.12
 click
 paho-mqtt
 pymodbus
-SungrowModbusTcpClient>=0.1.5
+SungrowModbusTcpClient>=0.1.6

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         'paho-mqtt>=1.5.0',
         'pymodbus>=2.3.0',
         'click>=6.7',
-        'SungrowModbusTcpClient>=0.1.5',
+        'SungrowModbusTcpClient>=0.1.6',
     ],
     tests_require=[
         'nose2>=0.9.2',


### PR DESCRIPTION
…cement.

This is blocked on: https://github.com/rpvelloso/Sungrow-Modbus/pull/7

This is a fix for #37 