### PR TITLE
Add LWT and modbus status publishing.

### DIFF
--- a/modbus4mqtt/modbus4mqtt.py
+++ b/modbus4mqtt/modbus4mqtt.py
@@ -102,6 +102,7 @@ class mqtt_interface():
         if self.use_tls:
             self._mqtt_client.tls_set(ca_certs=self.cafile, certfile=self.cert, keyfile=self.key)
             self._mqtt_client.tls_insecure_set(self.insecure)
+        self._mqtt_client.will_set(self.prefix + 'modbus4mqtt', 'modbus4mqtt v{} disconnected.'.format(version.version))
         self._mqtt_client.connect(self.hostname, self._port, 60)
         self._mqtt_client.loop_start()
 

--- a/modbus4mqtt/modbus4mqtt.py
+++ b/modbus4mqtt/modbus4mqtt.py
@@ -64,7 +64,7 @@ class mqtt_interface():
         failed_attempts = 1
         while self._mb.connect():
             logging.warning("Modbus connection attempt {} failed. Retrying...".format(failed_attempts))
-            if failed_attempts == 1:
+            if failed_attempts == 1 and self._mqtt_client.is_connected():
                 self._mqtt_client.publish(self.prefix + 'modbus4mqtt/modbus_status',
                                           json.dumps({
                                               "status": "offline",
@@ -78,12 +78,13 @@ class mqtt_interface():
                 # This weird break is here because we mock out modbus_connection_failed in the tests
                 break
             sleep(self.modbus_reconnect_sleep_interval)
-        self._mqtt_client.publish(self.prefix + 'modbus4mqtt/modbus_status',
-                                  json.dumps({
-                                      "status": "online",
-                                      "timestamp": datetime.now().astimezone().strftime('%Y-%m-%dT%H:%M:%S%z')
-                                  })
-                                  )
+        if self._mqtt_client.is_connected():
+            self._mqtt_client.publish(self.prefix + 'modbus4mqtt/modbus_status',
+                                      json.dumps({
+                                          "status": "online",
+                                          "timestamp": datetime.now().astimezone().strftime('%Y-%m-%dT%H:%M:%S%z')
+                                      })
+                                      )
         # Tells the modbus interface about the registers we consider interesting.
         for register in self.registers:
             self._mb.add_monitor_register(register.get('table', 'holding'), register['address'], register.get('type', 'uint16'))


### PR DESCRIPTION
Closes #61 .

# Implemented changes
- [x]  Modbus status is published under `<prefix>/modbus4mqtt/modbus_status` in JSON format.
   -  JSON content:
      - `status`: any of `online`, `offline` or `reconnecting`, describing current modbus state
      - `timestamp`: contains a timestamp in ISO 8601 format  (e.g. `2024-09-24T01:23:45+0000`) of the latest published status change.
    - The status is only published on state change.
- [x] The connection message published under `<prefix>/modbus4mqtt` is now updated to a more complete Last Will Topic in JSON format.
 -  JSON content:
      - `status`: any of `online`, `offline`, describing current connection state.
      - `version`: contains the modbus4mqtt version
      - `timestamp`: contains a timestamp in ISO 8601 format  (e.g. `2024-09-24T01:23:45+0000`) of the latest published status change.
 
### To implement (requiring feedback):
- [ ] Brief explanation in Readme.md
- [ ] Move `connect_modbus()` after `connect_mqtt()`on startup (see [comment](https://github.com/tjhowse/modbus4mqtt/issues/61#issuecomment-2372573662))
- [ ] Add retain flag to all above messages
OR
- [ ] Add either a command line option or a configuration entry to set retain  flag for the above messages
